### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 client.py -c $(python3 -c \"print(input('chatroom: '))\") -u $(python3 -c \"print(input('username: ')"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # jsonstore-chatroom
 A peer-to-peer trust-based chatroom using jsonstore.io
+[![Run on Repl.it](https://repl.it/badge/github/AgeOfMarcus/jsonstore-chatroom)](https://repl.it/github/AgeOfMarcus/jsonstore-chatroom)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MarcusWeinberger/jsonstore-chatroom).